### PR TITLE
Use ghcs in PATH as default

### DIFF
--- a/1.1.0/haskell-language-server/tools/chocolateyinstall.ps1
+++ b/1.1.0/haskell-language-server/tools/chocolateyinstall.ps1
@@ -39,6 +39,7 @@ function Install-Hls($ghcVersion) {
 }
 
 function Get-InstalledGhcVersions() {
+  Update-SessionEnvironment
   $ghcExes = $(Get-Command ghc -All).path
 
   $versions = foreach ($ghc in $ghcExes) {

--- a/1.1.0/haskell-language-server/tools/chocolateyinstall.ps1
+++ b/1.1.0/haskell-language-server/tools/chocolateyinstall.ps1
@@ -63,7 +63,7 @@ if ($pp['for-all-ghcs']) {
     Write-Host "Installing $packageName for the selected ghc versions: $($ghcVersions -join ', ')" 
   }
 } else {
-  $ghcVersions = Get-InstalledGhcVersions
+  $ghcVersions = Get-InstalledGhcVersions | Get-Unique
   if ($ghcVersions.Count -le 0) {
     Write-Host `
      "There is no ghc versions in PATH. Installing for the default ghc version $($supportedVersions[0])"
@@ -91,7 +91,7 @@ if ($supportedInstalledGhcs.Count -le 0) {
   exit -1
 }
 
-Write-Host "Installing $packageName for the selected and supported ghc versions: $($ghcVersions -join ', ')"
+Write-Host "Installing $packageName for the selected and supported ghc versions: $($supportedInstalledGhcs -join ', ')"
 
 ForEach ($ghcVersion in $supportedInstalledGhcs) {
   Write-Host "Installing $packageName $ghcVersion"


### PR DESCRIPTION
* As choco automatic checker dont let use `choco list`: https://community.chocolatey.org/packages/haskell-language-server/1.1.0 i switch the default ghc version discovery to search in PATH
* Not sure about the possible caveats 😟 

//cc @mistuke i hope i am not pesting you too much